### PR TITLE
Improve mobile UX

### DIFF
--- a/src/components/IngredientCardList.jsx
+++ b/src/components/IngredientCardList.jsx
@@ -1,10 +1,18 @@
 import { motion, AnimatePresence } from "motion/react";
 
-export default function IngredientCardList({ ingredients, onRemove }) {
+export default function IngredientCardList({
+  ingredients,
+  onRemove,
+  limit = Infinity,
+  onShowMore,
+}) {
+    const displayIngredients = ingredients.slice(0, limit);
+    const remaining = ingredients.length - displayIngredients.length;
+
     return (
         <div className="flex flex-wrap gap-3">
             <AnimatePresence>
-                {ingredients.map((item, index) => (
+                {displayIngredients.map((item, index) => (
                     <motion.div
                         key={index}
                         className="flex items-center bg-orange-50 text-orange-700 rounded-full px-4 py-2 shadow-sm border border-orange-200"
@@ -23,6 +31,14 @@ export default function IngredientCardList({ ingredients, onRemove }) {
                     </motion.div>
                 ))}
             </AnimatePresence>
+            {remaining > 0 && (
+                <button
+                    onClick={onShowMore}
+                    className="bg-orange-50 text-orange-700 rounded-full px-4 py-2 shadow-sm border border-orange-200 text-sm"
+                >
+                    ＋{remaining}
+                </button>
+            )}
         </div>
     );
 }

--- a/src/components/IngredientInput.jsx
+++ b/src/components/IngredientInput.jsx
@@ -15,7 +15,7 @@ export default function IngredientInput({
     const unitOptions = ["g", "kg", "ml", "l", "個", "本", "枚", "適量"];
 
     return (
-        <div className="flex gap-3 mb-4 flex-nowrap items-center">
+        <div className="space-y-3 mb-4">
             <Input
                 placeholder="食材名"
                 value={ingredientName}
@@ -28,31 +28,33 @@ export default function IngredientInput({
                         handleAddIngredient();
                     }
                 }}
-                className="w-2/5 rounded-full h-12 text-base"
+                className="w-full rounded-full h-12 text-base"
             />
-            <Input
-                placeholder="数量 (例: 200)"
-                value={ingredientAmount}
-                onChange={(e) => setIngredientAmount(e.target.value)}
-                className="w-1/5 rounded-full h-12 text-base"
-            />
-            <select
-                value={ingredientUnit}
-                onChange={(e) => setIngredientUnit(e.target.value)}
-                className="w-1/5 rounded-full border-gray-300 text-gray-500 px-3 h-12 text-base cursor-pointer"
-            >
-                {unitOptions.map((unit) => (
-                    <option key={unit} value={unit}>
-                        {unit}
-                    </option>
-                ))}
-            </select>
-            <Button
-                className="rounded-full bg-gradient-to-r from-[#FF8855] to-[#FF7043] text-white shadow-md hover:scale-105 transition px-6 py-6 text-base cursor-pointer"
-                onClick={handleAddIngredient}
-            >
-                ➕ 追加
-            </Button>
+            <div className="flex gap-3 items-center">
+                <Input
+                    placeholder="数量"
+                    value={ingredientAmount}
+                    onChange={(e) => setIngredientAmount(e.target.value)}
+                    className="w-1/3 rounded-full h-12 text-base"
+                />
+                <select
+                    value={ingredientUnit}
+                    onChange={(e) => setIngredientUnit(e.target.value)}
+                    className="w-1/3 rounded-full border-gray-300 text-gray-500 px-3 h-12 text-base cursor-pointer"
+                >
+                    {unitOptions.map((unit) => (
+                        <option key={unit} value={unit}>
+                            {unit}
+                        </option>
+                    ))}
+                </select>
+                <Button
+                    className="flex-1 rounded-full bg-gradient-to-r from-[#FF8855] to-[#FF7043] text-white shadow-md hover:scale-105 transition px-6 py-6 text-base"
+                    onClick={handleAddIngredient}
+                >
+                    ➕ 追加
+                </Button>
+            </div>
         </div>
     );
 }

--- a/src/components/InventoryDialog.jsx
+++ b/src/components/InventoryDialog.jsx
@@ -1,0 +1,55 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import React from "react";
+
+export default function InventoryDialog({ isOpen, onClose, ingredients, setIngredients }) {
+  const unitOptions = ["g", "kg", "ml", "l", "個", "本", "枚", "適量"]; 
+
+  const handleChange = (index, key, value) => {
+    setIngredients(prev => prev.map((item, i) => i === index ? { ...item, [key]: value } : item));
+  };
+
+  const handleRemove = (index) => {
+    setIngredients(prev => prev.filter((_, i) => i !== index));
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-bold text-orange-500">食材リスト</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3 max-h-[60vh] overflow-y-auto py-2">
+          {ingredients.map((item, idx) => (
+            <div key={idx} className="flex items-center gap-2">
+              <div className="flex-1 text-sm">{item.displayName}</div>
+              <Input
+                value={item.quantity}
+                onChange={(e) => handleChange(idx, 'quantity', e.target.value)}
+                className="w-16 h-8 text-sm"
+              />
+              <select
+                value={item.unit}
+                onChange={(e) => handleChange(idx, 'unit', e.target.value)}
+                className="h-8 rounded-md border-gray-300 text-gray-500 text-sm"
+              >
+                {unitOptions.map(u => <option key={u} value={u}>{u}</option>)}
+              </select>
+              <button
+                onClick={() => handleRemove(idx)}
+                className="text-red-500 text-xs px-2"
+              >
+                削除
+              </button>
+            </div>
+          ))}
+        </div>
+        <DialogFooter>
+          <Button onClick={onClose} className="w-full bg-orange-400 hover:bg-orange-500 text-white">閉じる</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Header from "@/components/Header";
 import IngredientInput from "@/components/IngredientInput";
 import IngredientSelector from "@/components/IngredientSelector";
@@ -8,6 +8,8 @@ import CookingTimeInput from "@/components/CookingTimeInput";
 import IngredientCardList from "@/components/IngredientCardList.jsx";
 import RecipeDialog from "@/components/RecipeDialog.jsx";
 import FeedbackDialog from "@/components/FeedbackDialog";
+import CookingTypeSelector from "@/components/CookingTypeSelector.jsx";
+import InventoryDialog from "@/components/InventoryDialog.jsx";
 import useMainPageState from "@/hooks/useMainPageState";
 
 export default function MainPage() {
@@ -17,6 +19,7 @@ export default function MainPage() {
         ingredientUnit, setIngredientUnit,
         availableIngredients, setAvailableIngredients,
         mustHaveList, setMustHaveList,
+        cookingType, setCookingType,
         cookingTime, setCookingTime,
         isLoading, isDialogOpen,
         setIsDialogOpen, isAdding, setFeedbackCandidate,
@@ -25,6 +28,9 @@ export default function MainPage() {
         feedbackCandidate, handleFeedbackSubmit,
         handleAddIngredient, handleStartCooking, handleReset,
     } = useMainPageState();
+
+    const [isInventoryOpen, setIsInventoryOpen] = useState(false);
+    const [showMoodDetail, setShowMoodDetail] = useState(false);
 
     const emojiMap = Object.fromEntries(
         availableIngredients.map(item => [item.displayName, item.emoji || "❓"])
@@ -35,7 +41,7 @@ export default function MainPage() {
             <Header/>
 
             <div className="flex-1 flex justify-center items-start py-6 px-2">
-                <div className="max-w-3xl w-full space-y-6 relative">
+                <div className="max-w-3xl w-full space-y-6 relative pb-32">
                     <header className="text-center">
                         <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold text-[#FF8855] mb-3 tracking-tight drop-shadow">
                             ミステリーレシピ
@@ -65,6 +71,8 @@ export default function MainPage() {
 
                         <IngredientCardList
                             ingredients={availableIngredients}
+                            limit={3}
+                            onShowMore={() => setIsInventoryOpen(true)}
                             onRemove={(index) =>
                                 setAvailableIngredients(
                                     availableIngredients.filter((_, i) => i !== index)
@@ -72,8 +80,14 @@ export default function MainPage() {
                             }
                         />
 
-                        <h2 className="text-2xl font-semibold text-gray-700">
-                            🌤️ 今日の気分
+                        <h2 className="text-2xl font-semibold text-gray-700 flex items-center justify-between">
+                            <span>🌤️ 今日の気分</span>
+                            <button
+                                onClick={() => setShowMoodDetail(!showMoodDetail)}
+                                className="text-sm text-gray-500 underline"
+                            >
+                                {showMoodDetail ? "閉じる" : "詳細設定"}
+                            </button>
                         </h2>
 
                         <div>
@@ -92,14 +106,24 @@ export default function MainPage() {
                             cookingTime={cookingTime}
                             setCookingTime={setCookingTime}
                         />
+
+                        {showMoodDetail && (
+                            <div>
+                                <p className="font-medium mb-1">🍽️ 調理タイプ</p>
+                                <CookingTypeSelector
+                                    cookingType={cookingType}
+                                    setCookingType={setCookingType}
+                                />
+                            </div>
+                        )}
                     </section>
 
-                    <div className="text-center">
+                    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 w-[calc(100%-2rem)] max-w-md text-center z-20">
                         <Button
                             size="lg"
                             onClick={handleStartCooking}
                             disabled={isLoading}
-                            className="text-lg font-bold rounded-full py-6 px-8 bg-gradient-to-r from-[#FF8855] to-[#FF7043] text-white shadow-lg transition-all duration-300 ease-in-out transform hover:scale-105 active:scale-95"
+                            className="w-full text-lg font-bold rounded-full py-6 px-8 bg-gradient-to-r from-[#FF8855] to-[#FF7043] text-white shadow-lg transition-all duration-300 ease-in-out transform hover:scale-105 active:scale-95"
                         >
                             {isLoading ? "生成中..." : "🍳 料理を始める"}
                         </Button>
@@ -122,6 +146,13 @@ export default function MainPage() {
                             handleSubmit={handleFeedbackSubmit}
                         />
                     )}
+
+                    <InventoryDialog
+                        isOpen={isInventoryOpen}
+                        onClose={() => setIsInventoryOpen(false)}
+                        ingredients={availableIngredients}
+                        setIngredients={setAvailableIngredients}
+                    />
 
                     <LoadingOverlay isLoading={isLoading} isAdding={isAdding}/>
                 </div>


### PR DESCRIPTION
## Summary
- reorganize ingredient input into two rows
- limit displayed ingredient tags to 3 and show a `+N` button
- add inventory dialog to edit or delete ingredients
- collapse mood settings with optional cooking type selector
- keep main CTA fixed at bottom

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687b3f6eca1c832fa5e7ae05d489951a